### PR TITLE
feat: Add limitation to number of tasks showing

### DIFF
--- a/fastapi_bgtasks_dashboard/core.py
+++ b/fastapi_bgtasks_dashboard/core.py
@@ -14,6 +14,9 @@ _ws_lock = threading.Lock()
 # Store actual function objects for rerun
 _registered_funcs: dict = {}
 
+# Max tasks limit
+_max_tasks: int = 10000
+
 router = APIRouter()
 
 
@@ -90,13 +93,15 @@ def _wrap_task(func, *args, **kwargs):
             "ended_at": None,
             "params": bound_params,
         }
+
     _broadcast_update()
 
     def _runner():
         nonlocal started_at, ended_at
         with _tasks_lock:
-            _tasks[task_id]["status"] = "running"
-            _tasks[task_id]["started_at"] = datetime.utcnow()
+            if task_id in _tasks:
+                _tasks[task_id]["status"] = "running"
+                _tasks[task_id]["started_at"] = datetime.utcnow()
         _broadcast_update()
 
         try:
@@ -109,16 +114,38 @@ def _wrap_task(func, *args, **kwargs):
                 else:
                     asyncio.get_event_loop().run_until_complete(result)
             with _tasks_lock:
-                _tasks[task_id]["status"] = "finished"
+                if task_id in _tasks:
+                    _tasks[task_id]["status"] = "finished"
         except Exception as e:
             tb = traceback.format_exc()
             with _tasks_lock:
-                _tasks[task_id]["status"] = f"failed: {str(e)}"
-                _tasks[task_id]["error_trace"] = tb
+                if task_id in _tasks:
+                    _tasks[task_id]["status"] = f"failed: {str(e)}"
+                    _tasks[task_id]["error_trace"] = tb
         finally:
             ended_at = datetime.utcnow()
             with _tasks_lock:
-                _tasks[task_id]["ended_at"] = ended_at
+                if task_id in _tasks:
+                    _tasks[task_id]["ended_at"] = ended_at
+
+                # Enforce max tasks limit after task completion
+                if len(_tasks) > _max_tasks:
+                    # Sort tasks by ended_at, then started_at (oldest first)
+                    # Prioritize removing completed tasks over running ones
+                    tasks_by_time = sorted(
+                        _tasks.items(),
+                        key=lambda x: (
+                            x[1].get("ended_at") or datetime.max,
+                            x[1].get("started_at") or datetime.max
+                        )
+                    )
+                    # Remove oldest completed tasks to get back to limit
+                    num_to_remove = len(_tasks) - _max_tasks
+                    for i in range(num_to_remove):
+                        # Only remove tasks that have ended
+                        if tasks_by_time[i][1].get("ended_at"):
+                            del _tasks[tasks_by_time[i][0]]
+
             _broadcast_update()
 
     return _runner

--- a/fastapi_bgtasks_dashboard/route.py
+++ b/fastapi_bgtasks_dashboard/route.py
@@ -1,10 +1,22 @@
 from fastapi import APIRouter, FastAPI, BackgroundTasks
 from .core import _wrap_task
 from .dashboard import router
+from . import core
 
 
 # Mount background tasks dashboard.
-def mount_bg_tasks_dashboard(app: FastAPI = None, mount_dashboard: bool = True):
+def mount_bg_tasks_dashboard(app: FastAPI = None, mount_dashboard: bool = True, max_tasks: int = 10000):
+    """
+    Mount background tasks dashboard to your FastAPI application.
+
+    Args:
+        app: FastAPI application instance (optional)
+        mount_dashboard: Whether to mount the dashboard UI (default: True)
+        max_tasks: Maximum number of tasks to keep in memory (default: 10000)
+    """
+    # Set the max tasks limit
+    core._max_tasks = max_tasks
+
     if getattr(BackgroundTasks, "_patched_by_bgtasks_dashboard", False):
         if app and mount_dashboard:
             app.include_router(router)


### PR DESCRIPTION
## Description

- feat: Add limit of 10000 tasks to avoid mem issues

## Screenshots

Simulation with limited number of tasks showing on the dashboard:

<img width="1380" height="808" alt="Screenshot 2025-10-03 at 23 36 45" src="https://github.com/user-attachments/assets/11689854-9712-4602-9910-199429714c7a" />
<img width="166" height="504" alt="Screenshot 2025-10-03 at 23 37 01" src="https://github.com/user-attachments/assets/f685564f-5da4-4cb4-8630-70b9e45a65ae" />

## Issue

- https://github.com/Harshil-Jani/fastapi-bgtasks-dashboard/issues/1